### PR TITLE
feature/add-lazy-loading-composables

### DIFF
--- a/composables/useCulinary.ts
+++ b/composables/useCulinary.ts
@@ -1,6 +1,9 @@
 import { getCulinaryList, CulinaryApi } from "~/services/api";
+import type { AsyncDataOptions } from "#app";
+import type { CulinaryResult } from "~/services/api";
 
-export const useCulinary = () => {
+// AsyncDataOptions<CulinaryResult> : 表示 獲取資料後，要回傳的型別
+export const useCulinary = (options?: AsyncDataOptions<CulinaryResult>) => {
   return useAsyncData("culinaryResponse", async () => {
     const culinaryResponse = await getCulinaryList()
 
@@ -22,7 +25,9 @@ export const useCulinary = () => {
         }
         // console.log("無緩存", "發送請求");
         return null; // 返回 null，會發送請求
-      }
+      },
+      lazy: false,
+      ...options
     }
   )
 }

--- a/composables/useNews.ts
+++ b/composables/useNews.ts
@@ -1,5 +1,7 @@
 import { getNewsList, NewsApi } from "~/services/api";
-export function useNews() {
+import type { AsyncDataOptions } from "#app";
+import type { NewsResult } from "~/services/api";
+export function useNews(options?: AsyncDataOptions<NewsResult>) {
   return useAsyncData(
     'newsResponse',
     async () => {
@@ -24,7 +26,9 @@ export function useNews() {
       }
       // console.log("無緩存", "發送請求");
       return null; // 返回 null ，會發送請求
-    }
+    },
+    lazy: false,
+    ...options
   }
   );
 }

--- a/composables/useRooms.ts
+++ b/composables/useRooms.ts
@@ -1,5 +1,7 @@
 import { getRoomsList, RoomsApi } from "~/services/api";
-export function useRooms() {
+import type { AsyncDataOptions } from "#app";
+import type { RoomsListResult } from "~/services/api";
+export function useRooms(options?: AsyncDataOptions<RoomsListResult>) {
   return useAsyncData(
     'roomsResponse',
     async () => {
@@ -24,7 +26,9 @@ export function useRooms() {
       }
       // console.log("無緩存", "發送請求");
       return null; // 返回 null ，會發送請求
-    }
+    },
+    lazy: false,
+    ...options
   }
   );
 }

--- a/composables/useSingleRooms.ts
+++ b/composables/useSingleRooms.ts
@@ -1,5 +1,7 @@
 import { getSingleRooms, RoomsApi } from "~/services/api";
-export function useSingleRooms(id: string) {
+import type { AsyncDataOptions } from "#app";
+import type { SingleRoomResult } from "~/services/api";
+export function useSingleRooms(id: string, options?: AsyncDataOptions<SingleRoomResult>) {
   return useAsyncData(
     'singleRoomResponse',
     async () => {
@@ -24,7 +26,9 @@ export function useSingleRooms(id: string) {
       }
       // console.log("無緩存", "發送請求");
       return null; // 返回 null ，會發送請求
-    }
+    },
+    lazy: false,
+    ...options
   }
   );
 }

--- a/services/api/culinary/culinary.ts
+++ b/services/api/culinary/culinary.ts
@@ -4,14 +4,15 @@ import { culinaryContract } from '~/services/contract';
 import { initContract } from '@ts-rest/core';
 
 
-export type Culinaryresponse = z.infer<typeof culinarySchema.culinaryListResponse>
+export type CulinaryResponse = z.infer<typeof culinarySchema.culinaryListResponse>
+export type CulinaryResult = z.infer<typeof culinarySchema.culinaryListResponse>['result']
 export type CulinaryItem = z.infer<typeof culinarySchema.culinaryItem>
 export const CulinaryApi = initContract().router({
   culinary: culinaryContract.getCulinaryListResponse
 })
 export const getCulinaryList = () => {
   const config = useRuntimeConfig();
-  return $fetch<Culinaryresponse>(culinaryContract.getCulinaryListResponse.path, {
+  return $fetch<CulinaryResponse>(culinaryContract.getCulinaryListResponse.path, {
     method: culinaryContract.getCulinaryListResponse.method,
     baseURL: config.public.apiBase
   });

--- a/services/api/news/news.ts
+++ b/services/api/news/news.ts
@@ -3,6 +3,7 @@ import { newsSchema } from '~/services/schema';
 import { newsContract } from '~/services/contract';
 import { initContract } from '@ts-rest/core';
 export type NewsResponse = z.infer<typeof newsSchema.newsListResponse>
+export type NewsResult = z.infer<typeof newsSchema.newsListResponse>['result']
 export type NewsItem = z.infer<typeof newsSchema.newsItem>;
 
 

--- a/services/api/room/rooms.ts
+++ b/services/api/room/rooms.ts
@@ -4,6 +4,8 @@ import { roomsContract } from "~/services/contract";
 import { initContract } from '@ts-rest/core';
 export type RoomsListResponse = z.infer<typeof roomsSchema.roomsList>
 export type SingleRoomResponse = z.infer<typeof roomsSchema.singleRoom>
+export type RoomsListResult = z.infer<typeof roomsSchema.roomsList>['result']
+export type SingleRoomResult = z.infer<typeof roomsSchema.singleRoom>['result']
 export type SingleRoomItem = z.infer<typeof roomsSchema.roomItem>
 
 export const RoomsApi = initContract().router({


### PR DESCRIPTION
# PR: feature/add-lazy-loading-composables

## 主旨：為各個 Composables 添加懶加載配置屬性

## 描述

本 PR 增強現有的 Composables 功能，引入 Nuxt 3 的懶加載機制，提升初始頁面加載效能和用戶體驗。

### 核心改進

1. **AsyncDataOptions 配置支持**
   - 所有 Composables (`useCulinary`, `useNews`, `useRooms`, `useSingleRooms`) 現在接受 `AsyncDataOptions` 參數
   - 允許在調用時靈活配置懶加載行為

2. **靈活的懶加載控制**
   - 通過 `options` 參數，可在組件層級動態配置 `lazy` 屬性
   - 預設設置 `lazy: false`，保持當前的預取行為
   - 調用時可覆蓋為 `lazy: true` 實現延遲加載

3. **保留現有的快取機制**
   - `getCachedData()` 回調函數保持不變
   - 避免重複請求的邏輯依然有效
   - 既往的數據驗證邏輯 (Zod schema) 保持完整

### 主要變更

#### 修改的 Composables

1. **`composables/useCulinary.ts`**
   ```typescript
   export const useCulinary = (options?: AsyncDataOptions<CulinaryResult>) => {
     return useAsyncData("culinaryResponse", async () => { ... }, {
       getCachedData() { ... },
       lazy: false,
       ...options  // ✨ 允許調用時覆蓋配置
     })
   }
   ```

2. **`composables/useNews.ts`**
   - 新增 `AsyncDataOptions<NewsResult>` 型別支持 ( 針對回傳的資料型別 )
   - 支援 `...options` 參數傳遞

3. **`composables/useRooms.ts`**
   - 新增 `AsyncDataOptions<RoomsListResult>` 型別支持
   - 支援 `...options` 參數傳遞

4. **`composables/useSingleRooms.ts`**
   - 新增 `AsyncDataOptions<SingleRoomResult>` 型別支持
   - 支援 `...options` 參數傳遞

### 使用範例

```typescript
// 方式 1：使用預設配置（同步預取）
const { data: roomList } = await useRooms();

// 方式 2：啟用懶加載
const { data: roomList } = await useRooms({ lazy: true });

// 方式 3：組合多個選項
const { data: singleRoom } = await useSingleRooms(roomId, {
  lazy: true,
  immediate: false,
  // 其他 AsyncDataOptions
});
```


